### PR TITLE
WIP; require config in each entrypoint/dependency

### DIFF
--- a/nameko/dependencies.py
+++ b/nameko/dependencies.py
@@ -460,3 +460,23 @@ def prepare_dependencies(container):
     return chain(
         prepare_injection_providers(container, include_dependencies=True),
         prepare_entrypoint_providers(container, include_dependencies=True))
+
+
+class ConfigValue(object):
+    """ Descriptor for DependencyProviders that accepts a bare value or a
+    callable that returns a value when invoked with the active
+    :class:`ServiceContainer` instance; the value is subsequently cached.
+    """
+    def __init__(self, default):
+        self.default = default
+        self.data = WeakKeyDictionary()
+
+    def __get__(self, instance, owner):
+        value = self.data.get(instance, self.default)
+        if callable(value):
+            value = value(instance.container)
+            self.data[instance] = value
+        return value
+
+    def __set__(self, instance, value):
+        self.data[instance] = value

--- a/test/test_multihomed.py
+++ b/test/test_multihomed.py
@@ -1,0 +1,55 @@
+from functools import partial
+
+from nameko.rpc import rpc
+from nameko.runners import ServiceRunner
+
+
+AMQP_URI_A = "amqp://guest:guest@localhost:5672/a"
+AMQP_URI_B = "amqp://guest:guest@localhost:5672/b"
+
+a_rpc = partial(rpc, uri=AMQP_URI_A)
+b_rpc = partial(rpc, uri=AMQP_URI_B)
+
+
+def get_config_value(key, container):
+    return container.config.get(key)
+
+
+class Service(object):
+
+    #external_rpc = rpc_proxy('external', uri=)
+
+    # all equivalent
+    @rpc(uri=AMQP_URI_A)
+    @rpc(uri=partial(get_config_value, "AMQP_URI_A"))
+    @a_rpc
+    def method_a(self):
+        pass
+
+    # all equivalent
+    @rpc(uri=AMQP_URI_B)
+    @rpc(uri=partial(get_config_value, "AMQP_URI_B"))
+    @b_rpc
+    def method_b(self):
+        pass
+
+    # without explicit uri we fall back to config['AMQP_URI']
+    @rpc
+    def method_c(self):
+        pass
+
+
+def test_multihomed(rabbit_config):
+
+    config = {
+        'AMQP_URI': rabbit_config['AMQP_URI'],
+        'AMQP_URI_A': AMQP_URI_A,
+        'AMQP_URI_B': AMQP_URI_B
+    }
+
+    runner = ServiceRunner(config)
+    runner.add_service(Service)
+    runner.start()
+
+    import ipdb; ipdb.set_trace()
+    pass


### PR DESCRIPTION
Potential pattern to support entrypoints/dependencies with non-global config. Raised for discussion.

Summary:

* You should be able to pass individually relevant config values into entrypoints/dependencies
* These may be bare values _or_ a callable that returns the value when called with the hosting ``container``
* Changes applied here for ``@timer``, ``@rpc`` and ``rpc_proxy``
* The timer implementation works fine

This pattern fundamentally clashes with the re-use of ``RpcConsumer``s and ``QueueConsumer``s by multiple ``RpcProvider`` instances (which may now use different AMQP URIs). Now may be the right time to rebuild our RPC implementation around shared channels, rather than shared dependencies.