### PR TITLE
http improvement suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,9 @@ spelling:
 test_docs:
 	spelling
 	docs
+
+install-dev:
+	pip install -e .[develop]
+
+install:
+	pip install -e .

--- a/nameko/web/handlers.py
+++ b/nameko/web/handlers.py
@@ -41,13 +41,13 @@ def response_from_result(result):
 class HttpRequestHandler(Entrypoint):
     server = WebServer()
 
-    def __init__(self, method, url, expected_exceptions=()):
+    def __init__(self, method, url, pass_req=False, expected_exceptions=()):
         self.method = method
         self.url = url
         self.expected_exceptions = expected_exceptions
 
-    def get_url_rule(self):
-        return Rule(self.url, methods=[self.method])
+    def get_url_rule(self, base_url):
+        return Rule(base_url + self.url, methods=[self.method])
 
     def setup(self):
         self.server.register_provider(self)
@@ -57,12 +57,7 @@ class HttpRequestHandler(Entrypoint):
         super(HttpRequestHandler, self).stop()
 
     def process_request_data(self, request):
-        if request.method == 'POST':
-            data = request.get_data()
-            args = (data,)
-        else:
-            args = ()
-
+        args = (request,)
         kwargs = request.path_values
         return args, kwargs
 

--- a/nameko/web/server.py
+++ b/nameko/web/server.py
@@ -14,6 +14,7 @@ from nameko.extensions import ProviderCollector, SharedExtension
 
 WEB_SERVER_HOST_CONFIG_KEY = 'WEB_SERVER_HOST'
 WEB_SERVER_PORT_CONFIG_KEY = 'WEB_SERVER_PORT'
+WEB_SERVER_BASEURL_CONFIG_KEY = 'WEB_SERVER_BASE_URL'
 
 
 class HttpOnlyProtocol(HttpProtocol):
@@ -81,8 +82,9 @@ class WebServer(ProviderCollector, SharedExtension):
 
     def make_url_map(self):
         url_map = Map()
+        base_url = self.container.config.get(WEB_SERVER_BASEURL_CONFIG_KEY, '')
         for provider in self._providers:
-            rule = provider.get_url_rule()
+            rule = provider.get_url_rule(base_url)
             rule.endpoint = provider
             url_map.add(rule)
         return url_map

--- a/nameko/web/websocket.py
+++ b/nameko/web/websocket.py
@@ -55,7 +55,7 @@ class WebSocketServer(SharedExtension, ProviderCollector):
             'data': data,
         })
 
-    def get_url_rule(self):
+    def get_url_rule(self, base_url):
         return Rule('/ws', methods=['GET'])
 
     def handle_request(self, request):

--- a/test/web/conftest.py
+++ b/test/web/conftest.py
@@ -16,6 +16,7 @@ def web_config(rabbit_config):
 
     cfg = rabbit_config
     cfg['WEB_SERVER_PORT'] = port
+    cfg['WEB_SERVER_BASE_URL'] = '/test'
     yield cfg
 
 
@@ -25,10 +26,11 @@ def web_session(web_config):
     from werkzeug.urls import url_join
 
     port = web_config['WEB_SERVER_PORT']
+    base_url = web_config['WEB_SERVER_BASE_URL']
 
     class WebSession(Session):
         def request(self, method, url, *args, **kwargs):
-            url = url_join('http://127.0.0.1:%d/' % port, url)
+            url = url_join('http://127.0.0.1:{}'.format(port), base_url + url)
             return Session.request(self, method, url, *args, **kwargs)
 
     sess = WebSession()

--- a/test/web/test_server.py
+++ b/test/web/test_server.py
@@ -9,11 +9,11 @@ from nameko.web.server import BaseHTTPServer
 class ExampleService(object):
 
     @http('GET', '/')
-    def do_index(self):
+    def do_index(self, req):
         return ''
 
     @http('GET', '/large')
-    def do_large(self):
+    def do_large(self, req):
         # more than a buffer's worth
         return 'x' * (10**6)
 


### PR DESCRIPTION
This PR should serves as a discussion, and should probably be split into two. 

configurable base URL for http server
=============================

Lets say I have a service `foobar` with a couple of URLs it serves `/spam` and  `/ni`.
I would like to serve this service at http://example.org/foobar or maybe at the root http://foobar.example.org
without having to change any of my application code. I may even choose to deploy multiple versions of the service e.g. http://example.org/foobar/v1 and http://example.org/foobar/v2
The application must be able to correctly generate absolute URLs for it's own. This may be required if the generated URLs are passed back to callers (html pages, service discovery URLs, ...)

My implementation added a config `WEB_SERVER_BASE_URL` which defaults to `''`.
I have not touched the websocket implementation, I need to do some reading first. I believe it should be possible to configure the URLs similarly via the config. I also think the service itself should be able to specify under which URL e.g. RPC should be served (instead of locking it to `/ws`). 


e.g.
```python

class Foobar(object):
    @http('GET', '/spam')
    def spam(self): 
            return 'check out ' + self.url_for(self.ni, 5)

    @http('GET', '/ni/<int:ham>')
    def ni(self, ham):
            ...
``` 
Running `Foobar` with defaults would serve `spam` and `ni` at the root of the domain. Running it with `WEB_SERVER_BASE_URL='/foobar/v1'` would serve `spam` and `ni` at `/foobar/v1/spam` and `/foobar/v1/ni` respectively.  


Raw Request object for http handlers
============================

It is more likely than not that I may want to access data from the incoming HTTP request, i.e. more than just the URL parameters/path segments and POST data. I also think it should be possible to parameterize the URL for a POST as I would for the GET and they should be handled consistently.

```python
@http('GET' , '/foo/<int:bar>')
def handle(self, req, bar):
    ...

@http('POST' , '/spam/<int:ham>')
def handle(self, req, ham):
    ...
```
it would also be consistent when creating hybird handlers like:
```python
@http(('GET', 'POST') , '/spam/<int:ham>')
def handle(self, req, ham):
    ...
```

I suggest to always pass the raw werkzeug `Request`  to the handler methods as first param after `self`, followed by all URL params. This is little overhead for any handler that does not need it, would be consistent across http-methods (GET, POST, ...) and would allow greater flexibility with handling incoming requests.

Another way of handling would be to make the req optional e.g.:
```python
@http('GET' , '/foo/<int:bar>', req=True)
def handle(self, bar, req):
    ...
```
or to make the request object available as an injection(don't very much like that).

