### PR TITLE
Optional interactive interpreters

### DIFF
--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -31,17 +31,18 @@ class ShellRunner(object):
         embed(banner1=self.banner, user_ns=self.local)
 
     def plain(self):
+        code.interact(banner=self.banner, local=self.local)
+
+    def start_shell(self, name):
+        available_shells = [name] if name else SHELLS
+
         # Support the regular Python interpreter startup script if someone
         # is using it.
         startup = os.environ.get('PYTHONSTARTUP')
         if startup and os.path.isfile(startup):
             with open(startup, 'r') as f:
                 eval(compile(f.read(), startup, 'exec'), self.local)
-
-        code.interact(banner=self.banner, local=self.local)
-
-    def start_shell(self, name):
-        available_shells = [name] if name else SHELLS
+            del os.environ['PYTHONSTARTUP']
 
         for name in available_shells:
             try:

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -13,10 +13,19 @@ from nameko.standalone.rpc import ClusterRpcProxy
 from nameko.standalone.events import event_dispatcher
 
 
+SHELLS = ['bpython', 'ipython']
+
+
 def init_parser(parser):
     parser.add_argument(
         '--broker', default='amqp://guest:guest@localhost',
         help='RabbitMQ broker url')
+    parser.add_argument(
+        '--interface', choices=SHELLS,
+        help='Specify an interactive interpreter interface.')
+    parser.add_argument(
+        '--plain', action='store_true',
+        help='Use the regular Python interpreter.')
     return parser
 
 
@@ -42,6 +51,27 @@ Usage:
     return module
 
 
+def bpython(banner, local):
+    import bpython
+    bpython.embed(banner=banner, locals_=local)
+
+
+def ipython(banner, local):
+    from IPython import embed
+    embed(banner1=banner, user_ns=local)
+
+
+def run_shell(shell=None, banner=None, local=None):
+    available_shells = [shell] if shell else SHELLS
+
+    for shell in available_shells:
+        try:
+            return globals()[shell](banner, local)
+        except ImportError:
+            pass
+    raise ImportError
+
+
 def main(args):
     banner = 'Nameko Python %s shell on %s\nBroker: %s' % (
         sys.version,
@@ -53,11 +83,17 @@ def main(args):
     ctx = {}
     ctx['n'] = make_nameko_helper(config)
 
-    # Support the regular Python interpreter startup script if someone
-    # is using it.
-    startup = os.environ.get('PYTHONSTARTUP')
-    if startup and os.path.isfile(startup):
-        with open(startup, 'r') as f:
-            eval(compile(f.read(), startup, 'exec'), ctx)
+    try:
+        if args.plain:
+            raise ImportError
 
-    code.interact(banner=banner, local=ctx)
+        run_shell(shell=args.interface, banner=banner, local=ctx)
+    except ImportError:
+        # Support the regular Python interpreter startup script if someone
+        # is using it.
+        startup = os.environ.get('PYTHONSTARTUP')
+        if startup and os.path.isfile(startup):
+            with open(startup, 'r') as f:
+                eval(compile(f.read(), startup, 'exec'), ctx)
+
+        code.interact(banner=banner, local=ctx)

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -44,6 +44,19 @@ def test_plain():
     local['n'].disconnect()
 
 
+def test_plain_fallback():
+    parser = setup_parser()
+    args = parser.parse_args(['shell', '--interface', 'bpython'])
+
+    with patch('nameko.cli.shell.code') as code:
+        main(args)
+
+    _, kwargs = code.interact.call_args
+    local = kwargs['local']
+    assert 'n' in local.keys()
+    local['n'].disconnect()
+
+
 def test_bpython():
     parser = setup_parser()
     args = parser.parse_args(['shell', '--interface', 'bpython'])

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -33,7 +33,7 @@ def test_basic(tmpdir):
 
 def test_plain():
     parser = setup_parser()
-    args = parser.parse_args(['shell', '--plain'])
+    args = parser.parse_args(['shell', '--interface', 'plain'])
 
     with patch('nameko.cli.shell.code') as code:
         main(args)

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -31,57 +31,81 @@ def test_basic(tmpdir):
     local['n'].disconnect()
 
 
-def test_plain():
+def test_plain(tmpdir):
     parser = setup_parser()
     args = parser.parse_args(['shell', '--interface', 'plain'])
 
-    with patch('nameko.cli.shell.code') as code:
-        main(args)
+    startup = tmpdir.join('startup.py')
+    startup.write('foo = 42')
+
+    with patch('nameko.cli.shell.os.environ') as environ:
+        environ.get.return_value = str(startup)
+        with patch('nameko.cli.shell.code') as code:
+            main(args)
 
     _, kwargs = code.interact.call_args
     local = kwargs['local']
     assert 'n' in local.keys()
+    assert local['foo'] == 42
     local['n'].disconnect()
 
 
-def test_plain_fallback():
+def test_plain_fallback(tmpdir):
     parser = setup_parser()
     args = parser.parse_args(['shell', '--interface', 'bpython'])
 
-    with patch('nameko.cli.shell.code') as code:
-        main(args)
+    startup = tmpdir.join('startup.py')
+    startup.write('foo = 42')
+
+    with patch('nameko.cli.shell.os.environ') as environ:
+        environ.get.return_value = str(startup)
+        with patch('nameko.cli.shell.code') as code:
+            main(args)
 
     _, kwargs = code.interact.call_args
     local = kwargs['local']
     assert 'n' in local.keys()
+    assert local['foo'] == 42
     local['n'].disconnect()
 
 
-def test_bpython():
+def test_bpython(tmpdir):
     parser = setup_parser()
     args = parser.parse_args(['shell', '--interface', 'bpython'])
+
+    startup = tmpdir.join('startup.py')
+    startup.write('foo = 42')
 
     sys.modules['bpython'] = Mock()
 
-    with patch('bpython.embed') as embed:
-        main(args)
+    with patch('nameko.cli.shell.os.environ') as environ:
+        environ.get.return_value = str(startup)
+        with patch('bpython.embed') as embed:
+            main(args)
 
     _, kwargs = embed.call_args
     local = kwargs['locals_']
     assert 'n' in local.keys()
+    assert local['foo'] == 42
     local['n'].disconnect()
 
 
-def test_ipython():
+def test_ipython(tmpdir):
     parser = setup_parser()
     args = parser.parse_args(['shell', '--interface', 'ipython'])
 
+    startup = tmpdir.join('startup.py')
+    startup.write('foo = 42')
+
     sys.modules['IPython'] = Mock()
 
-    with patch('IPython.embed') as embed:
-        main(args)
+    with patch('nameko.cli.shell.os.environ') as environ:
+        environ.get.return_value = str(startup)
+        with patch('IPython.embed') as embed:
+            main(args)
 
     _, kwargs = embed.call_args
     local = kwargs['user_ns']
     assert 'n' in local.keys()
+    assert local['foo'] == 42
     local['n'].disconnect()

--- a/test/cli/test_shell.py
+++ b/test/cli/test_shell.py
@@ -1,4 +1,5 @@
-from mock import patch
+import sys
+from mock import patch, Mock
 
 from nameko.standalone.rpc import ClusterProxy
 from nameko.cli.main import setup_parser
@@ -27,4 +28,47 @@ def test_basic(tmpdir):
     local = kwargs['local']
     assert 'n' in local.keys()
     assert local['foo'] == 42
+    local['n'].disconnect()
+
+
+def test_plain():
+    parser = setup_parser()
+    args = parser.parse_args(['shell', '--plain'])
+
+    with patch('nameko.cli.shell.code') as code:
+        main(args)
+
+    _, kwargs = code.interact.call_args
+    local = kwargs['local']
+    assert 'n' in local.keys()
+    local['n'].disconnect()
+
+
+def test_bpython():
+    parser = setup_parser()
+    args = parser.parse_args(['shell', '--interface', 'bpython'])
+
+    sys.modules['bpython'] = Mock()
+
+    with patch('bpython.embed') as embed:
+        main(args)
+
+    _, kwargs = embed.call_args
+    local = kwargs['locals_']
+    assert 'n' in local.keys()
+    local['n'].disconnect()
+
+
+def test_ipython():
+    parser = setup_parser()
+    args = parser.parse_args(['shell', '--interface', 'ipython'])
+
+    sys.modules['IPython'] = Mock()
+
+    with patch('IPython.embed') as embed:
+        main(args)
+
+    _, kwargs = embed.call_args
+    local = kwargs['user_ns']
+    assert 'n' in local.keys()
     local['n'].disconnect()


### PR DESCRIPTION
Implements issue #210.

This allows the optional use of bpython or IPython as the interactive interpreter. I used the referenced [Django code](https://github.com/django/django/blob/9996158db467f9bef8243fcc36dc3602570e3613/django/core/management/commands/shell.py) as an example for this implementation.