### PR TITLE
Use Makefile as source of truth for commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-# shortcuts for local dev
-#
-.PHONY: test flake8 pylint pytest docs spelling test_docs
+.PHONY: test flake8 pylint pytest test_docs docs spelling
 
 test: flake8 pylint pytest
 
@@ -14,12 +12,11 @@ pytest:
 	coverage run --concurrency=eventlet --source nameko -m pytest test
 	coverage report --fail-under=100
 
+test_docs: docs spelling
+
 docs:
-	tox -e docs
+	sphinx-build -n -b html -d docs/build/doctrees docs docs/build/html
 
 spelling:
-	tox -e spelling
-
-test_docs:
-	spelling
-	docs
+	sphinx-build -b spelling -d docs/build/doctrees docs docs/build/spelling
+	# sphinx-build -W -b linkcheck -d docs/build/doctrees docs docs/build/linkcheck

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ flake8:
 	flake8 nameko test
 
 pylint:
-	pylint nameko -E
+	pylint --rcfile=pylintrc nameko -E
 
 pytest:
 	coverage run --concurrency=eventlet --source nameko -m pytest test
-	coverage report --fail-under=100
+	coverage report --show-missing --fail-under=100
 
 test_docs: docs spelling
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,25 +25,18 @@ deps =
 
     latest: eventlet  # need something
 
+whitelist_externals = make
+
 commands =
     pip install --editable .[dev]
-    flake8 nameko test
-    pylint --rcfile=pylintrc nameko -E
-    coverage run --concurrency=eventlet --source nameko -m \
-        pytest test {posargs:--timeout=30}
-    coverage report --show-missing --fail-under=100
-
+    make test
 
 [testenv:docs]
-changedir = docs
 commands =
-    pip install --editable ..[docs]
-    sphinx-build -n -b html -d build/doctrees . build/html
-
+    pip install --editable .[docs]
+    make docs
 
 [testenv:spelling]
-changedir = docs
 commands =
-    pip install --editable ..[docs]
-    sphinx-build -b spelling -d build/doctrees . build/spelling
-    # sphinx-build -W -b linkcheck -d build/doctrees . build/linkcheck
+    pip install --editable .[docs]
+    make spelling


### PR DESCRIPTION
This will simplify a number of the changes to ``tox.ini`` in #250. Raised as a separate change for visibility and to slim down that PR.