### PR TITLE
Updated installation documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,4 +38,4 @@ On debian-based operating systems::
 
 For other platforms, consult the `RabbitMQ installation guidelines <https://www.rabbitmq.com/download.html>`_.
 
-The RabbitMQ broker will be ready to go as soon as it's installed -- it doesn't need any configuration. The examples in this documentation assume you have a broker running on the default ports on localhost.
+The RabbitMQ broker will be ready to go as soon as it's installed -- it doesn't need any configuration. The examples in this documentation assume you have a broker running on the default ports on localhost and the `rabbitmq_management <http://www.rabbitmq.com/management.html>`_ plugin is enabled.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -74,6 +74,7 @@ namespace
 onefinestay
 parallelization
 parallelize
+plugin
 pre
 programmatically
 pseudocode


### PR DESCRIPTION
A problem during setting up a fresh installation was encountered - the rabbitmq-server in version below 3.0 doesn't have the management plugin enabled by default.  