### PR TITLE
Fix get_container import in the service runner example

### DIFF
--- a/docs/examples/service_runner.py
+++ b/docs/examples/service_runner.py
@@ -1,5 +1,5 @@
 from nameko.runners import ServiceRunner
-from nameko.utils import get_container
+from nameko.testing.utils import get_container
 
 class ServiceA(object):
     name = "service_a"


### PR DESCRIPTION
`get_container` is in `nameko.testing.utils` not in `nameko.utils`.