### PR TITLE
Improved error message if the RabbitMQ management API is not reachable.

### DIFF
--- a/nameko/testing/rabbit.py
+++ b/nameko/testing/rabbit.py
@@ -2,6 +2,7 @@ import json
 
 from requests import HTTPError, Session, ConnectionError
 from six.moves.urllib.parse import quote  # pylint: disable=E0611
+import six
 
 __all__ = ['Client', 'HTTPError']
 
@@ -34,9 +35,11 @@ class Client(object):
 
         try:
             result = self._session.request(method, url, **kwargs)
-        except ConnectionError:
-            raise Exception('Connection error for the RabbitMQ management HTTP'
-                            ' API at {}, is it enabled?'.format(url))
+        except ConnectionError as exc:
+            six.raise_from(Exception(
+                'Connection error for the RabbitMQ management HTTP'
+                ' API at {}, is it enabled?'.format(url)
+            ), exc)
 
         result.raise_for_status()
         if result.content:

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -6,6 +6,7 @@ from requests import Response, HTTPError
 
 from nameko.constants import DEFAULT_MAX_WORKERS
 from nameko.rpc import rpc, Rpc
+from nameko.testing.rabbit import Client
 from nameko.testing.utils import (
     AnyInstanceOf, get_extension, get_container, wait_for_call,
     reset_rabbit_vhost, get_rabbit_connections, wait_for_worker_idle,
@@ -247,3 +248,13 @@ def test_wait_for_worker_idle(container_factory, rabbit_config):
     with eventlet.Timeout(1):
         gt.wait()
     assert container._worker_pool.free() == max_workers
+
+
+def test_rabbit_connection_refused_error():
+
+    bad_port_uri = 'http://guest:guest@localhost:11111'
+    with pytest.raises(Exception) as exc_info:
+        Client(bad_port_uri)
+
+    message = str(exc_info.value)
+    assert 'Connection error' in message

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -6,7 +6,7 @@ from requests import Response, HTTPError
 
 from nameko.constants import DEFAULT_MAX_WORKERS
 from nameko.rpc import rpc, Rpc
-from nameko.testing.rabbit import Client, ConnectionError
+from nameko.testing.rabbit import Client
 from nameko.testing.utils import (
     AnyInstanceOf, get_extension, get_container, wait_for_call,
     reset_rabbit_vhost, get_rabbit_connections, wait_for_worker_idle,

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -252,7 +252,8 @@ def test_wait_for_worker_idle(container_factory, rabbit_config):
 
 def test_rabbit_connection_refused_error():
 
-    bad_port_uri = 'http://localhost:11111'
+    # port 4 is an official unassigned port, so no one should be using it
+    bad_port_uri = 'http://localhost:4'
     with pytest.raises(Exception) as exc_info:
         Client(bad_port_uri)
 

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -250,9 +250,9 @@ def test_wait_for_worker_idle(container_factory, rabbit_config):
     assert container._worker_pool.free() == max_workers
 
 
-def test_rabbit_connectipdateon_refused_error():
+def test_rabbit_connection_refused_error():
 
-    bad_port_uri = 'http://guest:guest@localhost:11111'
+    bad_port_uri = 'http://localhost:11111'
     with pytest.raises(Exception) as exc_info:
         Client(bad_port_uri)
 

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -6,7 +6,7 @@ from requests import Response, HTTPError
 
 from nameko.constants import DEFAULT_MAX_WORKERS
 from nameko.rpc import rpc, Rpc
-from nameko.testing.rabbit import Client
+from nameko.testing.rabbit import Client, ConnectionError
 from nameko.testing.utils import (
     AnyInstanceOf, get_extension, get_container, wait_for_call,
     reset_rabbit_vhost, get_rabbit_connections, wait_for_worker_idle,
@@ -250,7 +250,7 @@ def test_wait_for_worker_idle(container_factory, rabbit_config):
     assert container._worker_pool.free() == max_workers
 
 
-def test_rabbit_connection_refused_error():
+def test_rabbit_connectipdateon_refused_error():
 
     bad_port_uri = 'http://guest:guest@localhost:11111'
     with pytest.raises(Exception) as exc_info:


### PR DESCRIPTION
During EuroPython 2015 sprint people got weird errors during setup, this pull request raises a friendlier, more clear exception if the RabbitMQ management API is not reachable.