### PR TITLE
Add support for custom error payload

### DIFF
--- a/docs/built_in_extensions.rst
+++ b/docs/built_in_extensions.rst
@@ -107,6 +107,35 @@ The HTTP entrypoint is built on top of `werkzeug <http://werkzeug.pocoo.org/>`_.
     Content-Length: 0
     Date: Fri, 13 Feb 2015 14:58:48 GMT
 
+Exceptions can be raised safely if added to ``expected_exceptions`` or if subclass from :class:`~nameko.exceptions.HttpError`:
+
+.. literalinclude:: examples/http_exceptions.py
+
+.. code-block:: shell
+
+    $ nameko run http_exceptions
+    starting services: http_exceptions_service
+
+.. code-block:: shell
+
+    $ curl -i http://localhost:8000/expected_exception
+    HTTP/1.1 400 BAD REQUEST
+    Content-Type: text/plain; charset=utf-8
+    Content-Length: 41
+    Date: Thu, 06 Aug 2015 10:03:39 GMT
+
+    Error: ApplicationError: Invalid request
+
+.. code-block:: shell
+
+    $ curl -i http://localhost:8000/expected_custom_exception
+    HTTP/1.1 400 BAD REQUEST
+    Content-Type: text/plain; charset=utf-8
+    Content-Length: 84
+    Date: Thu, 06 Aug 2015 09:53:56 GMT
+
+    {"code": 400, "description": "This is invalid request.", "error": "INVALID_REQUEST"}
+
 
 Timer
 -----

--- a/docs/examples/http_exceptions.py
+++ b/docs/examples/http_exceptions.py
@@ -1,0 +1,31 @@
+# http_exceptions.py
+
+import json
+
+from nameko.web.handlers import http
+from nameko.exceptions import HttpError
+
+
+class ApplicationError(Exception):
+    pass
+
+
+class ApplicationCustomError(HttpError):
+    pass
+
+
+class Service(object):
+    name = "http_exceptions_service"
+
+    @http('GET', '/expected_exception', expected_exceptions=ApplicationError)
+    def expected_exception(self, request):
+        raise ApplicationError("Invalid request")
+
+    @http('GET', '/expected_custom_exception',
+          expected_exceptions=ApplicationCustomError)
+    def expected_custom_exception(self, request):
+        raise ApplicationCustomError(json.dumps({
+            'error': 'INVALID_REQUEST',
+            'description': 'This is invalid request.',
+            'code': 400
+        }), 400)

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -170,3 +170,9 @@ class CommandError(Exception):
 
 class ConnectionNotFound(BadRequest):
     """Unknown websocket connection id"""
+
+class HttpError(Exception):
+    def __init__(self, payload, status_code):
+        self.payload = payload
+        self.status_code = status_code
+        super(HttpError, self).__init__(payload)

--- a/nameko/exceptions.py
+++ b/nameko/exceptions.py
@@ -171,6 +171,7 @@ class CommandError(Exception):
 class ConnectionNotFound(BadRequest):
     """Unknown websocket connection id"""
 
+
 class HttpError(Exception):
     def __init__(self, payload, status_code):
         self.payload = payload

--- a/nameko/web/handlers.py
+++ b/nameko/web/handlers.py
@@ -76,7 +76,7 @@ class HttpRequestHandler(Entrypoint):
 
             response = response_from_result(result)
 
-        except Exception as exc:
+        except (Exception, HttpError) as exc:
             payload = None
             if isinstance(exc, HttpError):
                 payload = exc.payload

--- a/test/web/test_http_handler.py
+++ b/test/web/test_http_handler.py
@@ -6,6 +6,7 @@ from werkzeug.wrappers import Response
 from nameko.exceptions import HttpError
 from nameko.web.handlers import http
 
+
 class CustomHttpError(HttpError):
     pass
 
@@ -45,7 +46,7 @@ class ExampleService(object):
         raise ValueError('oops')
 
     @http('GET', '/fail_custom_payload')
-    def fail_expected(self, request):
+    def fail_custom_payload(self, request):
         raise CustomHttpError(json.dumps({
             "error": "SOMETHING_IS_MISSING",
             "description": "Something is missing",
@@ -110,8 +111,8 @@ def test_bad_payload(web_session):
     assert rv.status_code == 500
     assert "Error: TypeError: Payload must be a string. Got `23`" in rv.text
 
+
 def test_custom_error_payload(web_session):
     rv = web_session.get('/fail_custom_payload')
     assert rv.status_code == 404
     assert rv.json()["description"] == "Something is missing"
-


### PR DESCRIPTION
It would be nice to allow to define custom payload when raising exceptions within HTTP handler. Also added documentation around expected_exceptions.