### PR TITLE
"pyamqp" should be suggest way of defining the protocol for rabbitmq

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -25,7 +25,7 @@ and providing a simple YAML configuration file:
 
     # foobar.yaml
 
-    AMQP_URI: 'amqp://guest:guest@localhost'
+    AMQP_URI: 'pyamqp://guest:guest@localhost'
 
     WEB_SERVER_ADDRESS: '0.0.0.0:8000'
 

--- a/docs/examples/standalone_events.py
+++ b/docs/examples/standalone_events.py
@@ -1,7 +1,7 @@
 from nameko.standalone.events import event_dispatcher
 
 config = {
-    'AMQP_URI': AMQP_URI  # e.g. "amqp://guest:guest@localhost"
+    'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
 }
 
 dispatch = event_dispatcher(config)

--- a/docs/examples/standalone_rpc.py
+++ b/docs/examples/standalone_rpc.py
@@ -1,7 +1,7 @@
 from nameko.standalone.rpc import ClusterRpcProxy
 
 config = {
-    'AMQP_URI': AMQP_URI  # e.g. "amqp://guest:guest@localhost"
+    'AMQP_URI': AMQP_URI  # e.g. "pyamqp://guest:guest@localhost"
 }
 
 with ClusterRpcProxy(config) as cluster_rpc:

--- a/docs/key_concepts.rst
+++ b/docs/key_concepts.rst
@@ -82,6 +82,8 @@ Each worker executes in its own greenthread. The maximum number of concurrent wo
 
 Workers are stateless so are inherently thread safe, but dependencies should ensure they are unique per worker or otherwise safe to be accessed concurrently by multiple workers.
 
+Unfortunately, many C-extensions that are using sockets and that would normally be considered thread-safe may not work with greenthreads. Among them `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_, `MySQLdb <http://mysql-python.sourceforge.net/MySQLdb.html>` and others.
+
 .. _extensions:
 
 Extensions

--- a/docs/similar_projects.rst
+++ b/docs/similar_projects.rst
@@ -22,7 +22,7 @@ Kombu
 
 Nameko's AMQP features are built using Kombu but don't include support for the "virtual" transports.
 
-Also, due to the usage of `eventlet <http://eventlet.net/>`_ for green concurrency, Nameko can't make use of C extensions such as `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ that Kombu uses by default if it's available. If you want to have `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ in your environment for other purposes than Nameko, you can force Kombu to use standard Python implementation of AMQP by defining broker urls as ``pyamqp://`` instead of ``amqp://``
+Also, due to the usage of `eventlet <http://eventlet.net/>`_ for green concurrency, Nameko can't make use of C-extensions such as `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ that Kombu uses by default if it's available. If you want to have `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ in your environment for other purposes than Nameko, you can force Kombu to use standard Python implementation of AMQP by defining broker urls as ``pyamqp://`` instead of ``amqp://``
 
 Eventlet
 --------

--- a/docs/similar_projects.rst
+++ b/docs/similar_projects.rst
@@ -20,4 +20,11 @@ Kombu
 
 `Kombu <http://kombu.readthedocs.org/>`_ is a Python messaging library, used by both Celery and Nameko. It exposes a high-level interface for AMQP and includes support for "virtual" transports, so can be run with non-AMQP transports such as Redis, ZeroMQ and MongoDB.
 
-Nameko's AMQP features are built using Kombu but don't include support for the "virtual" transports. Also, due to the usage of `eventlet <https://pypi.python.org/pypi/eventlet>`_ for green concurrency, Nameko can't make use of C extensions such as `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ that Kombu uses by default.
+Nameko's AMQP features are built using Kombu but don't include support for the "virtual" transports.
+
+Also, due to the usage of `eventlet <http://eventlet.net/>`_ for green concurrency, Nameko can't make use of C extensions such as `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ that Kombu uses by default if it's available. If you want to have `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ in your environment for other purposes than Nameko, you can force Kombu to use standard Python implementation of AMQP by defining broker urls as ``pyamqp://`` instead of ``amqp://``
+
+Eventlet
+--------
+
+`Eventlet <http://eventlet.net/>`_ is a Python library that provides concurrency via "greenthreads". You can check more details on how it's used by Nameko in :ref:`Concurrency <concurrency>` section.

--- a/docs/similar_projects.rst
+++ b/docs/similar_projects.rst
@@ -20,4 +20,4 @@ Kombu
 
 `Kombu <http://kombu.readthedocs.org/>`_ is a Python messaging library, used by both Celery and Nameko. It exposes a high-level interface for AMQP and includes support for "virtual" transports, so can be run with non-AMQP transports such as Redis, ZeroMQ and MongoDB.
 
-Nameko's AMQP features are built using Kombu but don't include support for the "virtual" transports.
+Nameko's AMQP features are built using Kombu but don't include support for the "virtual" transports. Also, due to the usage of `eventlet <https://pypi.python.org/pypi/eventlet>`_ for green concurrency, Nameko can't make use of C extensions such as `librabbitmq <https://pypi.python.org/pypi/librabbitmq>`_ that Kombu uses by default.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -33,6 +33,7 @@ deserialized
 deserializers
 deserializes
 deserializing
+e
 entrypoint
 entrypoints
 eventlet
@@ -41,6 +42,7 @@ freenode
 greenthread
 greenthreads
 homebrew
+i
 init
 initialize
 initialized
@@ -107,6 +109,7 @@ serialized
 serializers
 serializes
 serializing
+shutdown
 specialization
 specialize
 specialized
@@ -120,6 +123,7 @@ submodules
 subpackages
 teardown
 testability
+timeouts
 traceback
 tracebacks
 tuple
@@ -130,9 +134,11 @@ unregister
 unregistered
 unregisters
 utils
+urls
 visualize
 visualized
 visualizing
+vs
 webapp
 websocket
 websockets

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -56,6 +56,7 @@ javascript
 kombu
 kwarg
 kwargs
+librabbitmq
 lifealike
 lifecycle
 localhost
@@ -72,6 +73,7 @@ mixin
 monolith
 monolithic
 monospaced
+mysqldb
 nameko
 namespace
 onefinestay
@@ -82,6 +84,7 @@ pre
 programmatically
 pseudocode
 py
+pyamqp
 pyrabbit
 pytest
 rabbitmq


### PR DESCRIPTION
Kombu will try to use librabbitmq if available and when using nameko on standalone basis (without eventlet and monkey patching). This will throw exception due to incompatibility between the two.

Using "pyamqp" instead of "amqp" will force Kombu to always use the pure Python implementation and not attempt to use librabbitmq.

"amqp" is an alias for "pymyqp" anyway