### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ increment the minor version number only.
 Version 2.4.0
 -------------
 
-Released PENDING
+Released 2016-08-30
 
 * Add dictionary access to ``standalone.rpc.ClusterProxy`` to allow the proxy
   to call services whose name is not a legal identifier in python
@@ -24,6 +24,7 @@ Released PENDING
   previously used to "whitelist" worker context data passed from call to call.
   It was a feature that leaked from a specific implementation into the main framework, and not useful enough in its own right to continue to be
   supported.
+* Refactor `ServiceContainer` internals for better separation between "managed" and "worker" threads. Improved logging when threads are killed.
 
 Version 2.3.1
 -------------
@@ -32,8 +33,7 @@ Released 2016-05-11
 
 * Deprecate ``MethodProxy.async`` in favour of ``MethodProxy.call_async`` in preparation for async becoming a keyword
 * Add support for loading logging configuration from ``config.yaml``
-* Refactor `ServiceContainer` internals for better separation between "managed"
-and "worker" threads. Improved logging when threads are killed.
+
 
 Version 2.3.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:
 
 setup(
     name='nameko',
-    version='2.3.2',
+    version='2.4.0',
     description='A microservices framework for Python that lets service '
                 'developers concentrate on application logic and encourages '
                 'testability.',


### PR DESCRIPTION
Also correct changelog - `ServiceContainer` refactor was not released with 2.3.1