### PR TITLE
Connection pool for multithreaded gevent-monkeypatched apps (e. g. using Nameko with Django)

### DIFF
--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -331,13 +331,12 @@ class ClusterRpcProxy(StandaloneProxyBase):
 
 
 class RPCProxyPool(object):
-    """
-    Connection pool for Nameko RPC cluster.
+    """ Connection pool for Nameko RPC cluster.
 
     Pool size can be customized by passing `pool_size` keyword argument to the constructor.
     Default size is 4.
 
-    Example usage:
+    *Usage*
 
         pool = RPCProxyPool()
         # ...

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -364,8 +364,7 @@ class RPCProxyPool(object):
             self.queue.put(ctx)
 
     def next(self):
-        """
-        Fetch next connection.
+        """ Fetch next connection.
 
         This method is thread-safe.
         """


### PR DESCRIPTION
Hi,

I've recently discovered Nameko and instantly fell in love with it. Great work!

The only thing I am missing was connection pooling mechanism: spamming server with RPC calls sometimes led to GEvent exceptions about using same socket by multiple greenlets.

So I decided to implement a simple connection pooling class to use Nameko with my Django apps.

Usage is fairly simple:

```
from nameko.standalone.rpc import RPCProxyPool

pool = RPCProxyPool(pool_size=8)

# Within django view or model:
with pool.next() as rpc:
    rpc.mailer.send_mail(foo='bar')
```

It uses gevent-powered Queue for pooling connections. Once there are no more free connections to reuse, it will block until a connection becomes available. Later we can implement dynamic pool size to create more connections if the pool is drained for a longer time.

I tested my code with siege, and here's what happened:
- Creating one ClusterRPCProxy per request: 10~20 RPS + driving RabbitMQ nuts (~50% availability).
- Creating global shared ClusterRPCProxy for all requests: ~50 RPS with periodic crashes (~70% availability)
- Using RPCProxyPool: ~110 RPS (100% availability).

I hope this code helps. I'm open to any comments to make it even better.