### PR TITLE
restore resilience to race conditions in events integration tests

### DIFF
--- a/test/test_events.py
+++ b/test/test_events.py
@@ -12,7 +12,7 @@ from nameko.messaging import QueueConsumer
 from nameko.standalone.events import event_dispatcher as standalone_dispatcher
 from nameko.testing.services import entrypoint_waiter
 from nameko.testing.utils import DummyProvider
-from nameko.testing.waiting import wait_for_call
+
 
 EVENTS_TIMEOUT = 5
 

--- a/test/test_queue_consumer.py
+++ b/test/test_queue_consumer.py
@@ -7,7 +7,6 @@ from eventlet.event import Event
 from kombu import Connection, Exchange, Queue
 from kombu.exceptions import TimeoutError
 from mock import ANY, Mock, call, patch
-
 from nameko.constants import AMQP_URI_CONFIG_KEY
 from nameko.messaging import QueueConsumer
 from nameko.rpc import RpcConsumer, rpc


### PR DESCRIPTION
Fixes the flakey tests introduced by https://github.com/onefinestay/nameko/pull/363